### PR TITLE
ENG-1839: Document GET /v1/devices/sync-status endpoints

### DIFF
--- a/api-reference/endpoint/v1/get-device-sync-status.mdx
+++ b/api-reference/endpoint/v1/get-device-sync-status.mdx
@@ -1,0 +1,4 @@
+---
+title: "Get Device Sync Status"
+openapi: "Get /v1/devices/{id}/sync-status"
+---

--- a/api-reference/endpoint/v1/list-device-sync-status.mdx
+++ b/api-reference/endpoint/v1/list-device-sync-status.mdx
@@ -1,0 +1,4 @@
+---
+title: "List Device Sync Status"
+openapi: "Get /v1/devices/sync-status"
+---

--- a/docs.json
+++ b/docs.json
@@ -36,6 +36,8 @@
                 "group": "Devices",
                 "pages": ["api-reference/endpoint/v1/list-devices",
                 "api-reference/endpoint/v1/get-device",
+                "api-reference/endpoint/v1/list-device-sync-status",
+                "api-reference/endpoint/v1/get-device-sync-status",
                 "api-reference/endpoint/v1/edit-device",
                 "api-reference/endpoint/v1/send-command",
                 "api-reference/endpoint/v1/batch-commands",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -340,11 +340,11 @@ paths:
               required: false
               schema:
                  type: integer
-                 default: 500
-                 maximum: 500
+                 default: 400
+                 maximum: 400
                  minimum: 1
               description: |
-                 Maximum number of devices to return per page. Default and maximum are both 500.
+                 Maximum number of devices to return per page. Default and maximum are both 400.
          responses:
             "200":
                description: A page of device sync statuses

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,7 +24,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
             - name: names
               in: query
@@ -159,7 +159,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -228,7 +228,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -302,13 +302,8 @@ paths:
       get:
          summary: List device sync status
          description: |
-            Retrieve per-content-category sync status for every device the API key has access to. Currently only `apps` is supported via the `include` query parameter.
+            Retrieve sync status details for devices. Currently supports fetching app sync statuses (installed vs. target version) only.
 
-            **Authentication:** API key only. Bearer-token auth is not supported on this endpoint.
-
-            **Pagination:** Cursor-based. Pass the `nextCursor` from the previous response back as `cursor` to fetch the next page. End of stream is indicated by `nextCursor: null` — do not infer end of stream from a short page. The cursor is opaque; treat it as a black box and do not parse or construct it manually.
-
-            **Multi-org API keys:** When `organizationId` is omitted, results are aggregated across every organization the API key has access to. The Firestore `in`-operator caps this at 30 organizations per request — keys with more than 30 authorized organizations must scope each request to a specific `organizationId`.
          parameters:
             - name: organizationId
               in: query
@@ -316,9 +311,9 @@ paths:
               schema:
                  type: string
               description: |
-                 Unique identifier of the organization. Only required for multi-organization API keys when scoping to a specific organization.
+                 Unique identifier of the organization. Defaults to all organizations the API key has access to. 
 
-                 Defaults to all organizations the API key has access to.
+                  **Multi-org API key limitation:** If your multi-org api key gives you access to more than 30 organizatinos, you must include a specific `organizationId` in this request.
             - name: include
               in: query
               required: true
@@ -334,7 +329,7 @@ paths:
               schema:
                  type: string
               description: |
-                 Opaque pagination cursor returned in `nextCursor` by a prior response. Treat as opaque.
+                 Opaque pagination cursor returned in `nextCursor` by a prior response. Treat as opaque. Pass the nextCursor from the previous response back as cursor to fetch the next page. End of stream is indicated by nextCursor: null — do not infer end of stream from a short page.
             - name: limit
               in: query
               required: false
@@ -405,9 +400,7 @@ paths:
       get:
          summary: Get device sync status
          description: |
-            Retrieve per-content-category sync status for a single device. Currently only `apps` is supported via the `include` query parameter.
-
-            For a device's overall up-to-date status, use the top-level `outOfDate` boolean on `GET /v1/devices/{id}`. This endpoint provides per-app detail.
+            Retrieve app sync status details for devices. For a device's overall up-to-date status, use the top-level `outOfDate` boolean on `GET /v1/devices/{id}`. This endpoint provides per-app detail.
          parameters:
             - name: id
               in: path
@@ -518,7 +511,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -577,7 +570,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -763,9 +756,9 @@ paths:
                              data:
                                 type: object
                                 properties:
-                                    forceSync:
-                                       type: boolean
-                                       description: Optional parameter. If true, forces device to sync immediately regardless of update schedule set on configuration
+                                   forceSync:
+                                      type: boolean
+                                      description: Optional parameter. If true, forces device to sync immediately regardless of update schedule set on configuration
                         - title: Enable / Disable Tutorial Mode
                           type: object
                           properties:
@@ -880,7 +873,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -1251,7 +1244,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -1282,7 +1275,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -1322,7 +1315,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -1389,7 +1382,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -1600,7 +1593,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -1693,7 +1686,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -1868,7 +1861,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
 
          responses:
@@ -1939,7 +1932,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -2096,7 +2089,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -2295,7 +2288,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -2406,7 +2399,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
 
          responses:
@@ -2463,7 +2456,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -2613,7 +2606,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -2840,7 +2833,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3104,7 +3097,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
 
          responses:
@@ -3186,7 +3179,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3402,7 +3395,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3609,7 +3602,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -3654,7 +3647,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3714,7 +3707,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3799,7 +3792,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -3869,7 +3862,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -3886,9 +3879,9 @@ paths:
                            $ref: "#/components/schemas/V1ConfigurationVrContentPatch"
                            description: Updated set of VR content on the configuration. Content will appear on the Home Screen in the order it appears in the vrContent array.
                         kioskVrContent:
-                           description: | 
+                           description: |
                               Set the App or video to kiosk devices into.
-                              
+
                               Requirements: 
                               - The `deviceExperience` field must also be set to `KIOSK` or `KIOSK_VIDEO`
                               - The App or Video must be included in the configurations `vrContent` already (or in this request)
@@ -3896,9 +3889,9 @@ paths:
 
                         deviceExperienceMode:
                            type: string
-                           description: | 
+                           description: |
                               Device experience 
-                              
+
                               KIOSK is Kiosk App. Options vary by device type. See supported device information [here](https://help.managexr.com/en/articles/5281345-supported-devices).
                            enum: [HOME_SCREEN, KIOSK, KIOSK_VIDEO, DEFAULT]
                            example: HOME_SCREEN
@@ -3906,9 +3899,9 @@ paths:
                            type: string
                            description: |
                               Kiosk mode strictness level.
-                              
+
                               **DEFAULT** - Recommended setting. Standard kiosk experience on ManageXR. Allows access to Meta quick settings menu.
-                              
+
                               **KIOSK_APP** - Forces user to only remain in kiosk app and not access anything else on the device, including quick settings or other system apps. This may impact your ability to cast the device using native casting.
                            enum: [DEFAULT, KIOSK_APP]
                            example: DEFAULT
@@ -3925,8 +3918,9 @@ paths:
                         priorityWifiNetworkId:
                            type: string
                            nullable: true
-                           description: The id of the wi-fi network to set as the priority network. A device will always connect to the priority network over other networks if it is in range. |
-                              Set to `null` to clear the priority. 
+                           description:
+                              The id of the wi-fi network to set as the priority network. A device will always connect to the priority network over other networks if it is in range. |
+                              Set to `null` to clear the priority.
                            example: 1390KJDL139PJD
                         files:
                            $ref: "#/components/schemas/V1BundledFileEditDto"
@@ -3934,7 +3928,7 @@ paths:
                            type: string
                            description: |
                               Time zone for the configuration. Can be set to 'UNMANAGED', 'AUTO', or a specific time zone ID.
-                              
+
                               Valid timeZoneIds include:
                               - Pacific/Midway
                               - Pacific/Honolulu
@@ -4135,7 +4129,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -4205,7 +4199,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -4283,7 +4277,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -4370,7 +4364,7 @@ paths:
                  type: string
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -4399,7 +4393,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -4438,7 +4432,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          requestBody:
             required: true
@@ -4514,7 +4508,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -4556,7 +4550,7 @@ paths:
               schema: { type: string }
               description: |
                  Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys. 
-                 
+
                  Defaults to the organizationId associated with the API key.
          responses:
             "200":
@@ -6309,7 +6303,7 @@ components:
                   - WPA3_ENTERPRISE
                   - UNKNOWN
                example: WPA_ENTERPRISE
-            priorityWifiNetwork: 
+            priorityWifiNetwork:
                type: boolean
                description: Priority network. The device will always connect to this network over other networks when it is in range and available.
                example: false
@@ -6442,7 +6436,7 @@ components:
                           description: Unique identifier of app version on ManageXR. You can retrieve this using the List App Versions endpoint.
             properties:
                $ref: "#/components/schemas/V1VrContentProperties"
-            type: 
+            type:
                type: string
                enum: [app]
                example: app
@@ -6559,13 +6553,13 @@ components:
                   kioskVideoSettings:
                      type: object
                      properties:
-                        loopVideo: 
+                        loopVideo:
                            type: boolean
                            description: Whether to play the video on loop
                            example: true
                         loopVideoAfterNSecondsHeadsetOff:
-                           type: number 
-                           enum: [0, 3, 10, 20, 30, 60, 300,600]
+                           type: number
+                           enum: [0, 3, 10, 20, 30, 60, 300, 600]
                            description: Reset video play position to the beginning after headset has been taken off for N seconds
                            example: 30
       V1ConfigurationVrContentPatch:
@@ -6587,7 +6581,7 @@ components:
          mapping:
             appRelease: "#/components/schemas/V1AppReleaseIdentifier"
             appVersion: "#/components/schemas/V1AppVersionIdentifier"
-            video:      "#/components/schemas/V1VideoIdentifier"
+            video: "#/components/schemas/V1VideoIdentifier"
 
       V1ConfigurationVrContentResponse:
          type: array
@@ -6767,13 +6761,13 @@ components:
                type: object
                description: Only relevant if configuration `deviceExperienceMode` is `KIOSK_VIDEO`
                properties:
-                  loopVideo: 
+                  loopVideo:
                      type: boolean
                      description: Whether to play the video on loop
                      example: true
                   loopVideoAfterNSecondsHeadsetOff:
-                     type: number 
-                     enum: [0, 3, 10, 20, 30, 60, 300,600]
+                     type: number
+                     enum: [0, 3, 10, 20, 30, 60, 300, 600]
                      description: Reset video play position to the beginning after headset has been taken off for N seconds
                      example: 30
             files:
@@ -6788,7 +6782,7 @@ components:
                items:
                   oneOf:
                      - $ref: "#/components/schemas/V1WifiNetwork"
- 
+
       V1Device:
          type: object
          description: Full representation of a device managed in ManageXR

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -298,6 +298,211 @@ paths:
                         statusCode: 403
                         message: "Forbidden"
                         error: "ManageXR Error"
+   /v1/devices/sync-status:
+      get:
+         summary: List device sync status
+         description: |
+            Retrieve per-content-category sync status for every device the API key has access to. Currently only `apps` is supported via the `include` query parameter.
+
+            **Authentication:** API key only. Bearer-token auth is not supported on this endpoint.
+
+            **Pagination:** Cursor-based. Pass the `nextCursor` from the previous response back as `cursor` to fetch the next page. End of stream is indicated by `nextCursor: null` — do not infer end of stream from a short page. The cursor is opaque; treat it as a black box and do not parse or construct it manually.
+
+            **Multi-org API keys:** When `organizationId` is omitted, results are aggregated across every organization the API key has access to. The Firestore `in`-operator caps this at 30 organizations per request — keys with more than 30 authorized organizations must scope each request to a specific `organizationId`.
+         parameters:
+            - name: organizationId
+              in: query
+              required: false
+              schema:
+                 type: string
+              description: |
+                 Unique identifier of the organization. Only required for multi-organization API keys when scoping to a specific organization.
+
+                 Defaults to all organizations the API key has access to.
+            - name: include
+              in: query
+              required: true
+              schema:
+                 type: string
+                 enum:
+                    - apps
+              description: |
+                 Comma-separated list of content categories to include in the response. Currently only `apps` is supported. Required.
+            - name: cursor
+              in: query
+              required: false
+              schema:
+                 type: string
+              description: |
+                 Opaque pagination cursor returned in `nextCursor` by a prior response. Treat as opaque.
+            - name: limit
+              in: query
+              required: false
+              schema:
+                 type: integer
+                 default: 500
+                 maximum: 500
+                 minimum: 1
+              description: |
+                 Maximum number of devices to return per page. Default and maximum are both 500.
+         responses:
+            "200":
+               description: A page of device sync statuses
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           data:
+                              type: array
+                              items:
+                                 $ref: "#/components/schemas/V1DeviceSyncStatus"
+                           nextCursor:
+                              type: string
+                              nullable: true
+                              description: Opaque cursor for the next page, or `null` if this is the last page.
+            "400":
+               description: Bad request — missing/invalid `include`, malformed `cursor`, invalid `limit`, or more than 30 organizations in scope.
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           statusCode:
+                              type: number
+                              example: 400
+                           message:
+                              type: string
+                              example: "include is required"
+                           error:
+                              type: string
+                              example: "ManageXR Error"
+                     example:
+                        statusCode: 400
+                        message: "include is required"
+                        error: "ManageXR Error"
+            "403":
+               description: Forbidden
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           statusCode:
+                              type: number
+                              example: 403
+                           message:
+                              type: string
+                              example: "Forbidden"
+                           error:
+                              type: string
+                              example: "ManageXR Error"
+                     example:
+                        statusCode: 403
+                        message: "Forbidden"
+                        error: "ManageXR Error"
+   /v1/devices/{id}/sync-status:
+      get:
+         summary: Get device sync status
+         description: |
+            Retrieve per-content-category sync status for a single device. Currently only `apps` is supported via the `include` query parameter.
+
+            For a device's overall up-to-date status, use the top-level `outOfDate` boolean on `GET /v1/devices/{id}`. This endpoint provides per-app detail.
+         parameters:
+            - name: id
+              in: path
+              required: true
+              schema:
+                 type: string
+              description: Unique identifier (serial number) of the device.
+            - name: organizationId
+              in: query
+              required: false
+              schema:
+                 type: string
+              description: |
+                 Unique identifier of the organization. This parameter is only necessary when using multi-organization API keys.
+
+                 Defaults to the organizationId associated with the API key.
+            - name: include
+              in: query
+              required: true
+              schema:
+                 type: string
+                 enum:
+                    - apps
+              description: |
+                 Comma-separated list of content categories to include in the response. Currently only `apps` is supported. Required.
+         responses:
+            "200":
+               description: The device's sync status
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           data:
+                              $ref: "#/components/schemas/V1DeviceSyncStatus"
+            "400":
+               description: Bad request — missing or invalid `include`.
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           statusCode:
+                              type: number
+                              example: 400
+                           message:
+                              type: string
+                              example: "include is required"
+                           error:
+                              type: string
+                              example: "ManageXR Error"
+                     example:
+                        statusCode: 400
+                        message: "include is required"
+                        error: "ManageXR Error"
+            "404":
+               description: Device not found
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           statusCode:
+                              type: number
+                              example: 404
+                           message:
+                              type: string
+                              example: "Not found"
+                           error:
+                              type: string
+                              example: "ManageXR Error"
+                     example:
+                        statusCode: 404
+                        message: "Device with id 12345678901234 not found"
+                        error: "ManageXR Error"
+            "403":
+               description: Forbidden
+               content:
+                  application/json:
+                     schema:
+                        type: object
+                        properties:
+                           statusCode:
+                              type: number
+                              example: 403
+                           message:
+                              type: string
+                              example: "Forbidden"
+                           error:
+                              type: string
+                              example: "ManageXR Error"
+                     example:
+                        statusCode: 403
+                        message: "Forbidden"
+                        error: "ManageXR Error"
    /v1/devices/set-pause-updates:
       post:
          summary: Set pause updates for devices
@@ -6776,6 +6981,74 @@ components:
                         version:
                            type: string
                            example: "v14"
+      V1DeviceSyncStatusAppVersion:
+         type: object
+         description: Version identifier for an installed or target app. All fields are optional because not every app category reports version metadata (e.g. some external/store apps).
+         properties:
+            versionCode:
+               type: number
+               description: Numeric version code.
+               example: 700402468
+            versionName:
+               type: string
+               description: Human-readable version name.
+               example: "76.0.0.0.410"
+            versionLabel:
+               type: string
+               description: Optional release-channel label associated with the version.
+               example: "stable"
+      V1DeviceSyncStatusAppEntry:
+         type: object
+         description: Sync status for a single app on a device.
+         required:
+            - packageName
+            - installed
+            - outOfDate
+            - hasError
+         properties:
+            packageName:
+               type: string
+               description: Android package name of the app.
+               example: "com.oculus.panelapp.kiosk"
+            installed:
+               type: boolean
+               description: Whether the app is currently installed on the device. Reflects managed apps only — sideloaded apps are not represented.
+               example: true
+            outOfDate:
+               type: boolean
+               description: Whether the installed version differs from the configuration's target version.
+               example: false
+            hasError:
+               type: boolean
+               description: Whether the device reported an error for this app on its last sync.
+               example: false
+            currentVersion:
+               $ref: "#/components/schemas/V1DeviceSyncStatusAppVersion"
+            targetVersion:
+               $ref: "#/components/schemas/V1DeviceSyncStatusAppVersion"
+      V1DeviceSyncStatus:
+         type: object
+         description: |
+            Per-content-category sync status for a single device. Optional content fields (e.g. `appSyncStatuses`) are populated based on the `include` query parameter — fields for unrequested categories are omitted.
+
+            For a device's overall up-to-date status, use the top-level `outOfDate` boolean on `V1Device` (returned by `GET /v1/devices` and `GET /v1/devices/{id}`).
+         required:
+            - deviceId
+            - serial
+         properties:
+            deviceId:
+               type: string
+               description: The device ID (serial number).
+               example: "340YC10G8D14ML"
+            serial:
+               type: string
+               description: Device serial number.
+               example: "340YC10G8D14ML"
+            appSyncStatuses:
+               type: array
+               description: Per-app sync entries. Present when `include=apps` was passed; absent otherwise.
+               items:
+                  $ref: "#/components/schemas/V1DeviceSyncStatusAppEntry"
       WifiNetworkType:
          type: string
          enum: [OPEN, WPA, WPA_ENTERPRISE, WPA3, WPA3_ENTERPRISE, UNKNOWN]


### PR DESCRIPTION
Adds OpenAPI definitions and Mintlify pages for both sync-status endpoints shipped via ENG-1815 (single device) and ENG-1940 (paginated list).

DO_NOT_MERGE until list endpoint is released